### PR TITLE
[Gitcoin] Fix saving graph on iOS Safari

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -264,7 +264,7 @@ React.useEffect(()=>{
     canvas.draw(true);
   };
 
-  window.onbeforeunload = function(){
+  window.onpagehide = function(){
     var data = JSON.stringify( graph.serialize() );
     localStorage.setItem("litegraph", data );
   }


### PR DESCRIPTION
This PR fixes the graph not saving correctly on iOS Safari.

The `onbeforeunload` event handler in `App.js` which is responsible for saving the graph was replaced by `onpagehide`. The reason is that `onbeforeunload` is not supported by mobile Safari. For more information about this situation on iOS see here: [Link](https://webkit.org/blog/516/webkit-page-cache-ii-the-unload-event/).

`onpagehide` has basically the same behaviour as `onbeforeunload` and is even considered best practice when it comes to saving data when the user leaves the page. 
 