### PR TITLE
Fix iPhone double click zooming

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  touch-action: manipulation;
 }
 
 code {


### PR DESCRIPTION
Fixes #17 

This commit disables the double-tap to zoom feature on mobile devices.