### PR TITLE
Allow file reloads

### DIFF
--- a/src/dialogs/LoadDialog.js
+++ b/src/dialogs/LoadDialog.js
@@ -189,6 +189,7 @@ function LoadDialog(props) {
             id="loadjsonfile"
             type="file"
             name="file"
+            value=""
             onChange={e => {
               console.log("FILE", e.target.files[0]);
               var reader = new FileReader();


### PR DESCRIPTION
Currently (without this fix), to reload a file, you have to load a *different* file first, so that the onChange event will be triggered.  With this change, the value on the <input> is always reinitialized to an empty string.  This will cause the onChange event to be triggered whenever a file is selected.