### PR TITLE
IPFSGet hotfix

### DIFF
--- a/src/nodes/Network/IPFSGet.js
+++ b/src/nodes/Network/IPFSGet.js
@@ -18,6 +18,7 @@ IPFSGet.prototype.onAdded = async function() {
     EXPERIMENTAL: {
      pubsub: true,
    },
+   repo: 'ipfs-' + Math.random(),
    config: {
      Addresses: {
        Swarm: ['/dns4/wrtc-star1.par.dwebops.pub/tcp/443/wss/p2p-webrtc-star',


### PR DESCRIPTION
* restore repo config to fix repo lock error when creating >1 IPFSDownload module