### PR TITLE
Respecting Dynamic Provider in ERC20 Node

### DIFF
--- a/src/nodes/Components/ERC20Token.js
+++ b/src/nodes/Components/ERC20Token.js
@@ -220,6 +220,16 @@ ERC20Token.prototype.connectWeb3 = function() {
 
 ERC20Token.prototype.onExecute = async function() {
 
+  let optionalProvider = this.getInputData(0)
+  if(typeof optionalProvider != "undefined" && optionalProvider!=this.properties.provider){
+    this.onPropertyChanged("provider",optionalProvider)
+  }else if(typeof optionalProvider == "undefined"){
+    if(this.properties.provider!=defaultProvider){
+//      console.log("SET BACK TO DEFAULT!!!")
+      this.onPropertyChanged("provider",defaultProvider)
+    }
+  }
+
     let changed = false
 
   let symbol = this.getInputData(1)
@@ -321,6 +331,14 @@ ERC20Token.prototype.onExecute = async function() {
 
 
 
+};
+
+ERC20Token.prototype.onPropertyChanged = async function(name, value){
+  this.properties[name] = value;
+  if(name=="provider"){
+    this.connectWeb3()
+  }
+  return true;
 };
 
 ERC20Token.prototype.parseContract = function() {


### PR DESCRIPTION
I have deployed an ERC20 token to my local Ganache instance, but noticed that the ERC20 node wasn't respecting the provided blockchain address. I borrowed the logic from the Web3/Balance node, and it worked like a charm!

My local install updated `yarn.lock`, and I'm able to add that to this branch if you'd like.