### PR TITLE
fixed 404 error while yarn install

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8289,7 +8289,7 @@ concat-stream@^1.5.0, concat-stream@^1.5.1, concat-stream@^1.6.0:
 
 "concat-stream@github:hugomrdias/concat-stream#feat/smaller":
   version "2.0.0"
-  resolved "https://codeload.github.com/hugomrdias/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
+  resolved "https://codeload.github.com/max-mapper/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^3.0.2"


### PR DESCRIPTION
```
$ curl https://codeload.github.com/hugomrdias/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034
< HTTP/2 404 
* Connection #0 to host codeload.github.com left intact
404: Not Found
```

now:

```
$ curl https://codeload.github.com/max-mapper/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034
< HTTP/2 200 
< content-type: application/x-gzip
```

looks like there is no repo `hugomrdias/concat-stream`